### PR TITLE
Fix performance issue when generating filtered biome map

### DIFF
--- a/ScienceAlert.Experiments/BiomeFilter.cs
+++ b/ScienceAlert.Experiments/BiomeFilter.cs
@@ -87,7 +87,7 @@ namespace ScienceAlert.Experiments
         private bool VerifyBiomeResult(double lat, double lon, CBAttributeMapSO.MapAttribute target)
         {
             if (projectedMap == null) return true; // we'll have to assume it's accurate since we can't prove otherwise
-            if (target == null || target.mapColor == null) return true; // this shouldn't happen 
+            if (target == null || target.mapColor == null) return true; // this shouldn't happen
 
             lon -= Mathf.PI * 0.5f;
             if (lon < 0d) lon += Mathf.PI * 2d;
@@ -159,13 +159,14 @@ namespace ScienceAlert.Experiments
                     pixels[y * projection.width + x] = (Color32)newBody.BiomeMap.GetAtt(lat, lon).mapColor;
                 }
 
-                if (y % 5 == 0)
+                // Disabled to reduce performance impact, though it makes it take longer overall.
+                //if (y % 5 == 0)
                     yield return null;
             }
 
             projection.SetPixels32(pixels);
             projection.Apply();
- 
+
             current = newBody;
             projectedMap = projection;
             projector = null; // we're finished!

--- a/ScienceAlert.Experiments/BiomeFilter.cs
+++ b/ScienceAlert.Experiments/BiomeFilter.cs
@@ -151,22 +151,25 @@ namespace ScienceAlert.Experiments
                 worker.Abort();
             }
 
+            var projectionWidth = projection.width;
+            var projectionHeight = projection.height;
+
             worker = new Thread(() =>
             {
-                for (int y = 0; y < projection.height; ++y)
+                for (int y = 0; y < projectionHeight; ++y)
                 {
-                    for (int x = 0; x < projection.width; ++x)
+                    for (int x = 0; x < projectionWidth; ++x)
                     {
                         // convert x and y into uv coordinates
-                        float u = (float)x / projection.width;
-                        float v = (float)y / projection.height;
+                        float u = (float)x / projectionWidth;
+                        float v = (float)y / projectionHeight;
 
                         // convert uv coordinates into latitude and longitude
                         double lat = Math.PI * v - Math.PI * 0.5;
                         double lon = 2d * Math.PI * u + Math.PI * 0.5;
 
                         // set biome color in our clean texture
-                        pixels[y * projection.width + x] = (Color32)newBody.BiomeMap.GetAtt(lat, lon).mapColor;
+                        pixels[y * projectionWidth + x] = (Color32)newBody.BiomeMap.GetAtt(lat, lon).mapColor;
                     }
                 }
 

--- a/ScienceAlert.Experiments/ExperimentManager.cs
+++ b/ScienceAlert.Experiments/ExperimentManager.cs
@@ -40,7 +40,7 @@ namespace ScienceAlert.Experiments
         void Awake()
         {
             vesselStorage = gameObject.AddComponent<StorageCache>();
-            biomeFilter = gameObject.AddComponent<BiomeFilter>();
+            biomeFilter = GetComponent<BiomeFilter>();
             scienceAlert = gameObject.GetComponent<ScienceAlert>();
             audio = GetComponent<AudioPlayer>() ?? AudioPlayer.Audio;
 


### PR DESCRIPTION
Fixes #2 

The BiomeFilter object was getting added twice - once in ScienceAlert.cs and once in ExperimentManager.cs. This was causing the expensive texture processing function to run twice concurrently. I've changed the latter into a "get" instead.

However, even with that done the routine is still pretty expensive to run on the main thread, so I've refactored it to run on a background thread instead, and then update the texture on the main thread once done. This has completely fixed the lag issue.

Now, if you're not a fan of multithreading then I do have a simpler change without that, but there will still be a performance issue without it.
